### PR TITLE
Add Snap and AppImage support using electron-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 releases
+dist

--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ To execute the appImage.
 
 To install the Snap.
 ```
-sudo snap install ./dist/Bottle_0.0.4_amd64.snap --dangerous
+sudo snap install ./dist/Bottle_0.0.4.snap --dangerous
 ```

--- a/README.md
+++ b/README.md
@@ -60,3 +60,40 @@ npm install
 ```
 npm start
 ```
+
+# How to Build Snap and AppImage on Linux
+
+## 1. Download Electron-Builder
+
+To build the packages we need to install electon-builder.
+
+```
+yarn add electron-builder --dev
+```
+
+## 2. Build
+
+Download the repository and build. First, clone it.
+
+```
+git clone https://github.com/interplanaria/bottle.git
+```
+
+Then build the packages
+
+```
+cd bottle
+npm run dist
+```
+
+## 3. Run
+
+To execute the appImage.
+```
+./dist/Bottle_0.0.4.AppImage
+```
+
+To install the Snap.
+```
+sudo snap install ./dist/Bottle_0.0.4_amd64.snap --dangerous
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "dist": "build --linux snap"
   },
   "author": "",
   "license": "ISC",
@@ -17,5 +18,8 @@
     "route-parser": "0.0.5",
     "timeago.js": "^4.0.0-beta.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "electron": "^2.0.0",
+    "electron-builder": "^20.27.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,13 +26,14 @@
     "appId": "network.bitdb.bottle.torusJKL",
     "linux": {
       "target": ["snap","appImage"],
-      "description": "Bottle is a browser that lets you surf the Bitcoin network for these things, and brings them all together through Bitcoin native URI schemes such as B:// or C:// (or any other protocols we add in the future)."
+      "description": "Bottle is a browser that lets you surf the Bitcoin network for these things, and brings them all together through Bitcoin native URI schemes such as B:// or C:// (or any other protocols we add in the future).",
+      "category": "Network",
+      "artifactName": "${productName}_${version}.${ext}"
     }
   },
   "snap": {
     "grade": "stable",
-    "confinement": "strict",
-    "summary": "A Bitcoin Browser"
+    "confinement": "strict"
   },
   "appImage": {
     "systemIntegration": "ask"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "Bottle",
-  "version": "1.0.0",
+  "version": "0.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {
     "start": "electron .",
-    "dist": "build --linux snap"
+    "dist": "build"
   },
   "author": "",
   "license": "ISC",
@@ -21,5 +21,20 @@
   "devDependencies": {
     "electron": "^2.0.0",
     "electron-builder": "^20.27.1"
+  },
+  "build": {
+    "appId": "network.bitdb.bottle.torusJKL",
+    "linux": {
+      "target": ["snap","appImage"],
+      "description": "Bottle is a browser that lets you surf the Bitcoin network for these things, and brings them all together through Bitcoin native URI schemes such as B:// or C:// (or any other protocols we add in the future)."
+    }
+  },
+  "snap": {
+    "grade": "stable",
+    "confinement": "strict",
+    "summary": "A Bitcoin Browser"
+  },
+  "appImage": {
+    "systemIntegration": "ask"
   }
 }


### PR DESCRIPTION
Electron-Builder lets people create a Snap and AppImage to use Bottle on Linux.

The Snap has been published to the Snapcraft store
https://snapcraft.io/bottle

The AppImage could be distributed as a download.